### PR TITLE
More descriptive associated types in TransitionSystem/Guide.

### DIFF
--- a/dpar/src/guide/mod.rs
+++ b/dpar/src/guide/mod.rs
@@ -9,22 +9,22 @@ use system::{ParserState, Transition};
 
 /// Guide for parsers without batch processing
 pub trait Guide {
-    type T: Transition;
+    type Transition: Transition;
 
     /// Returns the best (permissible) transition given the current parser
     /// state.
-    fn best_transition(&mut self, state: &ParserState) -> Self::T;
+    fn best_transition(&mut self, state: &ParserState) -> Self::Transition;
 }
 
 /// Guide for parsers with batch processing
 pub trait BatchGuide {
-    type T: Transition;
+    type Transition: Transition;
 
     /// Returns the best (permissible) transitions for a slice of parser
     /// states. The transitions are returned in the same order as the
     /// parser states. So, the *0th* transition is the best transition
     /// for the *0th* parser state.
-    fn best_transitions(&mut self, states: &[&ParserState]) -> Vec<Self::T>;
+    fn best_transitions(&mut self, states: &[&ParserState]) -> Vec<Self::Transition>;
 }
 
 pub mod tensorflow;

--- a/dpar/src/guide/tensorflow/guide.rs
+++ b/dpar/src/guide/tensorflow/guide.rs
@@ -163,7 +163,7 @@ where
     }
 
     /// Find the best transition given a slice of transition logits.
-    fn logits_best_transition<S>(&self, state: &ParserState, logits: S) -> T::T
+    fn logits_best_transition<S>(&self, state: &ParserState, logits: S) -> T::Transition
     where
         S: AsRef<[f32]>,
     {
@@ -197,9 +197,9 @@ impl<T> Guide for TensorflowGuide<T>
 where
     T: TransitionSystem,
 {
-    type T = T::T;
+    type Transition = T::Transition;
 
-    fn best_transition(&mut self, state: &ParserState) -> Self::T {
+    fn best_transition(&mut self, state: &ParserState) -> Self::Transition {
         let v = self.vectorizer.realize(state);
 
         let mut input_tensors = EnumMap::new();
@@ -229,9 +229,9 @@ impl<T> BatchGuide for TensorflowGuide<T>
 where
     T: TransitionSystem,
 {
-    type T = T::T;
+    type Transition = T::Transition;
 
-    fn best_transitions(&mut self, states: &[&ParserState]) -> Vec<Self::T> {
+    fn best_transitions(&mut self, states: &[&ParserState]) -> Vec<Self::Transition> {
         if states.is_empty() {
             return Vec::new();
         }

--- a/dpar/src/models/tensorflow/model.rs
+++ b/dpar/src/models/tensorflow/model.rs
@@ -362,7 +362,7 @@ where
     /// Both the parser states and the feature representations of the parser
     /// states should be provided. Returns the best (possible) transition for
     /// each parser state.
-    pub fn predict(&mut self, states: &[&ParserState], input_tensors: &LayerTensors) -> Vec<T::T> {
+    pub fn predict(&mut self, states: &[&ParserState], input_tensors: &LayerTensors) -> Vec<T::Transition> {
         let logits = self.logits(input_tensors);
 
         let n_labels = logits.dims()[1] as usize;
@@ -380,7 +380,7 @@ where
     ///
     /// This method finds the best transition (largest logit) that is possible given the
     /// current parser state.
-    fn logits_best_transition(&self, state: &ParserState, logits: &[f32]) -> T::T {
+    fn logits_best_transition(&self, state: &ParserState, logits: &[f32]) -> T::Transition {
         // Invariant: we should have as many predictions as transitions.
         let n_predictions = logits.len();
         let n_transitions = self.system.transitions().len();

--- a/dpar/src/parser/greedy_parser.rs
+++ b/dpar/src/parser/greedy_parser.rs
@@ -30,7 +30,7 @@ where
     fn parse(&mut self, sentence: &Sentence) -> Result<DependencySet> {
         let mut state = ParserState::new(sentence);
 
-        while !<<G as Guide>::T as Transition>::S::is_terminal(&state) {
+        while !<<G as Guide>::Transition as Transition>::S::is_terminal(&state) {
             self.guide.best_transition(&state).apply(&mut state);
         }
 
@@ -51,7 +51,7 @@ where
                 let mut mapping = Vec::new();
 
                 for (idx, state) in states.iter().enumerate() {
-                    if !<<G as BatchGuide>::T as Transition>::S::is_terminal(state) {
+                    if !<<G as BatchGuide>::Transition as Transition>::S::is_terminal(state) {
                         active_states.push(state);
                         mapping.push(idx);
                     }

--- a/dpar/src/system/trans_system.rs
+++ b/dpar/src/system/trans_system.rs
@@ -9,13 +9,13 @@ use numberer::Numberer;
 use system::{DependencySet, ParserState};
 
 pub trait TransitionSystem {
-    type T: Transition;
-    type O: Guide<T = Self::T>;
+    type Transition: Transition;
+    type Oracle: Guide<Transition = Self::Transition>;
 
     fn is_terminal(state: &ParserState) -> bool;
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O;
-    fn transitions(&self) -> &Numberer<Self::T>;
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T>;
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle;
+    fn transitions(&self) -> &Numberer<Self::Transition>;
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition>;
 }
 
 pub trait Transition: Clone + Debug + Eq + Hash + Serialize + DeserializeOwned {

--- a/dpar/src/systems/arc_eager.rs
+++ b/dpar/src/systems/arc_eager.rs
@@ -28,22 +28,22 @@ impl Default for ArcEagerSystem {
 ///
 /// See: Joakim Nivre, Incrementality in Deterministic Dependency Parsing, 2004
 impl TransitionSystem for ArcEagerSystem {
-    type T = ArcEagerTransition;
-    type O = ArcEagerOracle;
+    type Transition = ArcEagerTransition;
+    type Oracle = ArcEagerOracle;
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty()
     }
 
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O {
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle {
         ArcEagerOracle::new(gold_dependencies)
     }
 
-    fn transitions(&self) -> &Numberer<Self::T> {
+    fn transitions(&self) -> &Numberer<Self::Transition> {
         &self.transitions
     }
 
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T> {
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition> {
         &mut self.transitions
     }
 }
@@ -144,7 +144,7 @@ impl ArcEagerOracle {
 }
 
 impl Guide for ArcEagerOracle {
-    type T = ArcEagerTransition;
+    type Transition = ArcEagerTransition;
 
     fn best_transition(&mut self, state: &ParserState) -> ArcEagerTransition {
         assert!(

--- a/dpar/src/systems/arc_hybrid.rs
+++ b/dpar/src/systems/arc_hybrid.rs
@@ -30,22 +30,22 @@ impl Default for ArcHybridSystem {
 }
 
 impl TransitionSystem for ArcHybridSystem {
-    type T = ArcHybridTransition;
-    type O = ArcHybridOracle;
+    type Transition = ArcHybridTransition;
+    type Oracle = ArcHybridOracle;
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1
     }
 
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O {
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle {
         ArcHybridOracle::new(gold_dependencies)
     }
 
-    fn transitions(&self) -> &Numberer<Self::T> {
+    fn transitions(&self) -> &Numberer<Self::Transition> {
         &self.transitions
     }
 
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T> {
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition> {
         &mut self.transitions
     }
 }
@@ -130,7 +130,7 @@ impl ArcHybridOracle {
 }
 
 impl Guide for ArcHybridOracle {
-    type T = ArcHybridTransition;
+    type Transition = ArcHybridTransition;
 
     fn best_transition(&mut self, state: &ParserState) -> ArcHybridTransition {
         assert!(

--- a/dpar/src/systems/arc_standard.rs
+++ b/dpar/src/systems/arc_standard.rs
@@ -26,22 +26,22 @@ impl Default for ArcStandardSystem {
 }
 
 impl TransitionSystem for ArcStandardSystem {
-    type T = ArcStandardTransition;
-    type O = ArcStandardOracle;
+    type Transition = ArcStandardTransition;
+    type Oracle = ArcStandardOracle;
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty()
     }
 
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O {
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle {
         ArcStandardOracle::new(gold_dependencies)
     }
 
-    fn transitions(&self) -> &Numberer<Self::T> {
+    fn transitions(&self) -> &Numberer<Self::Transition> {
         &self.transitions
     }
 
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T> {
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition> {
         &mut self.transitions
     }
 }
@@ -132,7 +132,7 @@ impl ArcStandardOracle {
 }
 
 impl Guide for ArcStandardOracle {
-    type T = ArcStandardTransition;
+    type Transition = ArcStandardTransition;
 
     fn best_transition(&mut self, state: &ParserState) -> ArcStandardTransition {
         let stack = &state.stack();

--- a/dpar/src/systems/stack_projective.rs
+++ b/dpar/src/systems/stack_projective.rs
@@ -26,22 +26,22 @@ impl Default for StackProjectiveSystem {
 }
 
 impl TransitionSystem for StackProjectiveSystem {
-    type T = StackProjectiveTransition;
-    type O = StackProjectiveOracle;
+    type Transition = StackProjectiveTransition;
+    type Oracle = StackProjectiveOracle;
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1
     }
 
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O {
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle {
         StackProjectiveOracle::new(gold_dependencies)
     }
 
-    fn transitions(&self) -> &Numberer<Self::T> {
+    fn transitions(&self) -> &Numberer<Self::Transition> {
         &self.transitions
     }
 
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T> {
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition> {
         &mut self.transitions
     }
 }
@@ -125,7 +125,7 @@ impl StackProjectiveOracle {
 }
 
 impl Guide for StackProjectiveOracle {
-    type T = StackProjectiveTransition;
+    type Transition = StackProjectiveTransition;
 
     fn best_transition(&mut self, state: &ParserState) -> StackProjectiveTransition {
         let stack = &state.stack();

--- a/dpar/src/systems/stack_swap.rs
+++ b/dpar/src/systems/stack_swap.rs
@@ -37,22 +37,22 @@ impl Default for StackSwapSystem {
 }
 
 impl TransitionSystem for StackSwapSystem {
-    type T = StackSwapTransition;
-    type O = StackSwapOracle;
+    type Transition = StackSwapTransition;
+    type Oracle = StackSwapOracle;
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1
     }
 
-    fn oracle(gold_dependencies: &DependencySet) -> Self::O {
+    fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle {
         StackSwapOracle::new(gold_dependencies)
     }
 
-    fn transitions(&self) -> &Numberer<Self::T> {
+    fn transitions(&self) -> &Numberer<Self::Transition> {
         &self.transitions
     }
 
-    fn transitions_mut(&mut self) -> &mut Numberer<Self::T> {
+    fn transitions_mut(&mut self) -> &mut Numberer<Self::Transition> {
         &mut self.transitions
     }
 }
@@ -153,7 +153,7 @@ impl StackSwapOracle {
 }
 
 impl Guide for StackSwapOracle {
-    type T = StackSwapTransition;
+    type Transition = StackSwapTransition;
 
     fn best_transition(&mut self, state: &ParserState) -> StackSwapTransition {
         let stack = &state.stack();

--- a/dpar/src/train/hdf5.rs
+++ b/dpar/src/train/hdf5.rs
@@ -47,7 +47,7 @@ impl<T> InstanceCollector<T> for HDF5Collector<T>
 where
     T: TransitionSystem,
 {
-    fn collect(&mut self, t: &T::T, state: &ParserState) -> Result<()> {
+    fn collect(&mut self, t: &T::Transition, state: &ParserState) -> Result<()> {
         let label = self.transition_system.transitions_mut().add(t.clone());
         let v = self.vectorizer.realize(state);
         self.writer.write(label, v)

--- a/dpar/src/train/mod.rs
+++ b/dpar/src/train/mod.rs
@@ -11,5 +11,5 @@ pub trait InstanceCollector<T>
 where
     T: TransitionSystem,
 {
-    fn collect(&mut self, t: &T::T, state: &ParserState) -> Result<()>;
+    fn collect(&mut self, t: &T::Transition, state: &ParserState) -> Result<()>;
 }


### PR DESCRIPTION
The one-letter names for the associated types in TransitionSystem and
Guide overlapped with generic type names. This made some types hard to
read. Rename these types as suggested by @twuebi in #7.

T -> Transition
O -> Oracle