### PR TITLE
Make LayerTensors a type alias.

### DIFF
--- a/dpar/src/models/tensorflow/guide.rs
+++ b/dpar/src/models/tensorflow/guide.rs
@@ -1,11 +1,8 @@
-use enum_map::EnumMap;
 use tensorflow::Tensor;
 
-use system::{ParserState, TransitionSystem};
-
 use guide::{BatchGuide, Guide};
-
-use super::{LayerTensors, TensorflowModel};
+use models::tensorflow::{InstanceSlices, LayerTensors, TensorflowModel};
+use system::{ParserState, TransitionSystem};
 
 impl<T> Guide for TensorflowModel<T>
 where
@@ -30,7 +27,7 @@ where
         }
 
         // Allocate batch tensors.
-        let mut input_tensors = LayerTensors(EnumMap::new());
+        let mut input_tensors = LayerTensors::new();
         for (layer, size) in self.vectorizer().layer_sizes() {
             input_tensors[layer] = Tensor::new(&[states.len() as u64, size as u64]).into();
         }

--- a/dpar/src/models/tensorflow/mod.rs
+++ b/dpar/src/models/tensorflow/mod.rs
@@ -5,3 +5,7 @@ pub use self::guide::*;
 
 mod model;
 pub use self::model::*;
+
+mod tensor;
+pub use self::tensor::LayerTensors;
+pub(crate) use self::tensor::*;

--- a/dpar/src/models/tensorflow/tensor.rs
+++ b/dpar/src/models/tensorflow/tensor.rs
@@ -1,0 +1,76 @@
+use std::ops::{Deref, DerefMut};
+
+use enum_map::EnumMap;
+
+use features::Layer;
+use tensorflow::{Tensor, TensorType};
+
+/// Ad-hoc trait for converting extracting slices from tensors.
+pub trait InstanceSlices<T> {
+    /// Extract for each layer the slice corresponding to the `idx`-th
+    /// instance from the batch.
+    fn to_instance_slices(&mut self, idx: usize) -> EnumMap<Layer, &mut [T]>;
+}
+
+impl<T> InstanceSlices<T> for LayerTensors<T>
+where
+    T: TensorType,
+{
+    fn to_instance_slices(&mut self, idx: usize) -> EnumMap<Layer, &mut [T]> {
+        let mut slices = EnumMap::new();
+
+        for (layer, tensor) in self.iter_mut() {
+            let layer_size = tensor.dims()[1] as usize;
+            let offset = idx * layer_size;
+            slices[layer] = &mut tensor[offset..offset + layer_size];
+        }
+
+        slices
+    }
+}
+
+pub type LayerTensors<T> = EnumMap<Layer, TensorWrap<T>>;
+
+/// Simple wrapper for `Tensor` that implements the `Default`
+/// trait.
+pub struct TensorWrap<T>(pub Tensor<T>)
+where
+    T: TensorType;
+
+impl<T> Default for TensorWrap<T>
+where
+    T: TensorType,
+{
+    fn default() -> Self {
+        TensorWrap(Tensor::new(&[]))
+    }
+}
+
+impl<T> From<Tensor<T>> for TensorWrap<T>
+where
+    T: TensorType,
+{
+    fn from(tensor: Tensor<T>) -> Self {
+        TensorWrap(tensor)
+    }
+}
+
+impl<T> Deref for TensorWrap<T>
+where
+    T: TensorType,
+{
+    type Target = Tensor<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for TensorWrap<T>
+where
+    T: TensorType,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}


### PR DESCRIPTION
Also move LayerTensors and TensorWrap to a separate module 'tensor'.

The motivation to keep the name LayerTensors is that writing
EnumMap<Layer, TensorWrap<T>> in various places is a little verbose.