### PR TITLE
Update build environment.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ stdenv.mkDerivation rec {
   env = buildEnv { name = name; paths = buildInputs; };
 
   nativeBuildInputs = [
-    cargo
     pkgconfig
-    ragelDev
+    latest.rustChannels.stable.rust
   ];
 
   buildInputs = [
+    curl
     hdf5
     libtensorflow
     openssl


### PR DESCRIPTION
- Use Rust from the Mozilla overlay.
- ragel is not necessary for normal builds and currently does not
  build on macOS. So disable/remove from now.
- curl is a build  dependency (at least on macOS) of one of the
  transitive dependencies of dpar.