### PR TITLE
Add dpar-prepare: a data preparation utility.

### DIFF
--- a/dpar-utils/src/bin/dpar-prepare.rs
+++ b/dpar-utils/src/bin/dpar-prepare.rs
@@ -1,0 +1,210 @@
+extern crate conllx;
+extern crate dpar;
+extern crate dpar_utils;
+extern crate getopts;
+#[macro_use]
+extern crate serde_derive;
+extern crate stdinout;
+extern crate toml;
+
+use std::collections::BTreeSet;
+use std::env::args;
+use std::fs::File;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::process;
+
+use conllx::{HeadProjectivizer, Projectivize, ReadSentence};
+use dpar::features::addr::Layer::Char;
+use dpar::features::{AddressedValues, InputVectorizer, Layer, Lookup};
+use dpar::system::{sentence_to_dependencies, ParserState};
+use dpar::systems::{
+    ArcEagerSystem, ArcHybridSystem, ArcStandardSystem, StackProjectiveSystem, StackSwapSystem,
+};
+use dpar::train::{GreedyTrainer, NoopCollector};
+use getopts::Options;
+use stdinout::{Input, Output};
+
+use dpar_utils::{Config, ErrorKind, OrExit, Result, SerializableTransitionSystem, TomlRead};
+
+/// Ad-hoc shapes structure, which can be used to construct the
+/// Tensorflow parsing graph.
+#[derive(Serialize)]
+struct Shapes {
+    batch_size: usize,
+    tokens: usize,
+    tags: usize,
+    deprels: usize,
+    features: usize,
+    chars: usize,
+    deprel_embeds: usize,
+    n_features: usize,
+    n_labels: usize,
+    prefix_len: usize,
+    suffix_len: usize,
+}
+
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {} [options] CONFIG TRAIN_DATA SHAPES", program);
+    print!("{}", opts.usage(&brief));
+}
+
+fn main() {
+    let args: Vec<String> = args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "print this help menu");
+    let matches = opts.parse(&args[1..]).or_exit();
+
+    if matches.opt_present("h") {
+        print_usage(&program, opts);
+        return;
+    }
+
+    if matches.free.is_empty() || matches.free.len() > 3 {
+        print_usage(&program, opts);
+        return;
+    }
+
+    let config_file = File::open(&matches.free[0]).or_exit();
+    let mut config = Config::from_toml_read(config_file).or_exit();
+    config.relativize_paths(&matches.free[0]).or_exit();
+
+    let input = Input::from(matches.free.get(1));
+    let treebank_reader = conllx::Reader::new(input.buf_read().or_exit());
+    let output = Output::from(matches.free.get(2));
+    let shapes_writer = output.write().or_exit();
+
+    prepare(&config, treebank_reader, shapes_writer).or_exit();
+}
+
+fn prepare<R, W>(config: &Config, treebank_reader: conllx::Reader<R>, shapes_write: W) -> Result<()>
+where
+    R: BufRead,
+    W: Write,
+{
+    let prepare_fun: Box<Fn(_, _, _) -> Result<_>> = match config.parser.system.as_ref() {
+        "arceager" => Box::new(prepare_with_system::<R, W, ArcEagerSystem>),
+        "archybrid" => Box::new(prepare_with_system::<R, W, ArcHybridSystem>),
+        "arcstandard" => Box::new(prepare_with_system::<R, W, ArcStandardSystem>),
+        "stackproj" => Box::new(prepare_with_system::<R, W, StackProjectiveSystem>),
+        "stackswap" => Box::new(prepare_with_system::<R, W, StackSwapSystem>),
+        _ => {
+            eprintln!("Unsupported transition system: {}", config.parser.system);
+            process::exit(1);
+        }
+    };
+
+    prepare_fun(config, treebank_reader, shapes_write)
+}
+
+fn prepare_with_system<R, W, S>(
+    config: &Config,
+    treebank_reader: conllx::Reader<R>,
+    shapes_write: W,
+) -> Result<()>
+where
+    R: BufRead,
+    S: SerializableTransitionSystem,
+    W: Write,
+{
+    let lookups = config.lookups.create_lookups()?;
+    let inputs = config.parser.load_inputs()?;
+    let vectorizer = InputVectorizer::new(lookups, inputs);
+    let system: S = S::default();
+    let collector = NoopCollector::new(system, vectorizer)?;
+    let mut trainer = GreedyTrainer::new(collector);
+    let projectivizer = HeadProjectivizer::new();
+
+    for sentence in treebank_reader.sentences() {
+        let sentence = if config.parser.pproj {
+            projectivizer.projectivize(&sentence?)?
+        } else {
+            sentence?
+        };
+
+        let dependencies = sentence_to_dependencies(&sentence).or_exit();
+
+        let mut state = ParserState::new(&sentence);
+        trainer.parse_state(&dependencies, &mut state)?;
+    }
+
+    write_transition_system(&config, trainer.collector().transition_system())?;
+
+    write_shapes(config, trainer, shapes_write)
+}
+
+/// Write shape TOML.
+fn write_shapes<W, S>(
+    config: &Config,
+    trainer: GreedyTrainer<S, NoopCollector<S>>,
+    mut shapes_write: W,
+) -> Result<()>
+where
+    W: Write,
+    S: SerializableTransitionSystem,
+{
+    let vectorizer = trainer.collector().input_vectorizer();
+    let layer_sizes = vectorizer.layer_sizes();
+    let layer_lookups = vectorizer.layer_lookups();
+
+    let (prefix_len, suffix_len) = affix_lengths(vectorizer.layer_addrs())?;
+
+    let shapes = Shapes {
+        batch_size: config.parser.train_batch_size,
+        tokens: layer_sizes[Layer::Token],
+        tags: layer_sizes[Layer::Tag],
+        deprels: layer_sizes[Layer::DepRel],
+        features: layer_sizes[Layer::Feature],
+        chars: layer_sizes[Layer::Char],
+        deprel_embeds: layer_lookups
+            .layer_lookup(Layer::DepRel)
+            .map(Lookup::len)
+            .unwrap_or(0),
+        n_features: layer_lookups
+            .layer_lookup(Layer::Feature)
+            .map(Lookup::len)
+            .unwrap_or(0),
+        n_labels: trainer.collector().transition_system().transitions().len(),
+        prefix_len,
+        suffix_len,
+    };
+
+    write!(shapes_write, "{}", toml::to_string(&shapes).or_exit());
+
+    Ok(())
+}
+
+fn affix_lengths(addrs: &AddressedValues) -> Result<(usize, usize)> {
+    let mut prefix_lens = BTreeSet::new();
+    let mut suffix_lens = BTreeSet::new();
+
+    for addr in &addrs.0 {
+        if let Char(prefix_len, suffix_len) = addr.layer {
+            prefix_lens.insert(prefix_len);
+            suffix_lens.insert(suffix_len);
+        }
+    }
+
+    if prefix_lens.len() != 1 || suffix_lens.len() != 1 {
+        Err(ErrorKind::ConfigError(
+            "Models with varying prefix or suffix lengths are not supported".into(),
+        ).into())
+    } else {
+        Ok((
+            prefix_lens.into_iter().next().unwrap(),
+            suffix_lens.into_iter().next().unwrap(),
+        ))
+    }
+}
+
+fn write_transition_system<T>(config: &Config, system: &T) -> Result<()>
+where
+    T: SerializableTransitionSystem,
+{
+    let transitions_path = Path::new(&config.parser.transitions);
+    let mut f = File::create(transitions_path)?;
+    system.to_cbor_write(&mut f)?;
+    Ok(())
+}

--- a/dpar/src/features/input_layers.rs
+++ b/dpar/src/features/input_layers.rs
@@ -4,6 +4,7 @@ use std::io::BufRead;
 use std::result;
 
 use enum_map::EnumMap;
+
 use features::addr;
 use features::lookup::BoxedLookup;
 use features::parse_addr::parse_addressed_values;
@@ -42,7 +43,7 @@ impl AddressedValues {
 ///
 /// `InputVector` instances represent feature vectors, also called
 /// input layers in neural networks. The input vector is split in
-/// vectors for differnt layers. In each layer, the feature is encoded
+/// vectors for different layers. In each layer, the feature is encoded
 /// as a 32-bit identifier, which is typically the row of the layer
 /// value in an embedding matrix.
 pub struct InputVector {
@@ -138,6 +139,10 @@ impl InputVectorizer {
             layer_lookups: layer_lookups,
             input_layer_addrs: input_addrs,
         }
+    }
+
+    pub fn layer_addrs(&self) -> &AddressedValues {
+        &self.input_layer_addrs
     }
 
     /// Get the layer lookups.

--- a/dpar/src/train/mod.rs
+++ b/dpar/src/train/mod.rs
@@ -4,6 +4,9 @@ use Result;
 mod trainer;
 pub use self::trainer::GreedyTrainer;
 
+mod noop;
+pub use self::noop::NoopCollector;
+
 pub trait InstanceCollector<T>
 where
     T: TransitionSystem,

--- a/dpar/src/train/noop.rs
+++ b/dpar/src/train/noop.rs
@@ -1,0 +1,49 @@
+use features::InputVectorizer;
+use system::{ParserState, TransitionSystem};
+use train::InstanceCollector;
+use Result;
+
+/// No-op collector.
+///
+/// The no-op collector implements the `InstanceCollector` trait, but
+/// does not actually collect any data. However, since this collector
+/// vectorizes parser states, it can be used for initializing lookup
+/// tables (as a side-effect of collection).
+pub struct NoopCollector<T> {
+    transition_system: T,
+    vectorizer: InputVectorizer,
+}
+
+impl<T> NoopCollector<T>
+where
+    T: TransitionSystem,
+{
+    /// Create a new `NoopCollector`.
+    pub fn new(transition_system: T, vectorizer: InputVectorizer) -> Result<Self> {
+        Ok(NoopCollector {
+            transition_system: transition_system,
+            vectorizer: vectorizer,
+        })
+    }
+
+    /// Get the vectorizer that is associated with the collector.
+    pub fn input_vectorizer(&self) -> &InputVectorizer {
+        &self.vectorizer
+    }
+
+    /// Get the transition system that is associated with the collector.
+    pub fn transition_system(&self) -> &T {
+        &self.transition_system
+    }
+}
+
+impl<T> InstanceCollector<T> for NoopCollector<T>
+where
+    T: TransitionSystem,
+{
+    fn collect(&mut self, t: &T::Transition, state: &ParserState) -> Result<()> {
+        self.transition_system.transitions().lookup(t.clone());
+        self.vectorizer.realize(state);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This utility constructs from the training data:

- The feature lookup tables.
- The transition lookup table.
- A TOML file with shape data.

The shape data can is used from a Python script to construct the Tensorflow graph.

The error reporting will/should be improved here as well, once we switch to `failure` and the most recent `stdinout` (cf #20 #17 ).