### PR TITLE
Remove stderr macro, use eprintln instead.

### DIFF
--- a/dpar-utils/src/bin/dpar-parse.rs
+++ b/dpar-utils/src/bin/dpar-parse.rs
@@ -1,6 +1,5 @@
 extern crate conllx;
 extern crate dpar;
-#[macro_use]
 extern crate dpar_utils;
 extern crate failure;
 extern crate getopts;
@@ -80,7 +79,7 @@ where
         "stackproj" => Box::new(parse_with_system::<R, W, StackProjectiveSystem>),
         "stackswap" => Box::new(parse_with_system::<R, W, StackSwapSystem>),
         _ => {
-            stderr!("Unsupported transition system: {}", config.parser.system);
+            eprintln!("Unsupported transition system: {}", config.parser.system);
             process::exit(1);
         }
     };
@@ -243,7 +242,7 @@ where
 {
     let transitions_path = Path::new(&config.parser.transitions);
 
-    stderr!("Loading transitions from: {:?}", transitions_path);
+    eprintln!("Loading transitions from: {:?}", transitions_path);
 
     let f = File::open(transitions_path)?;
     let system = T::from_cbor_read(f)?;

--- a/dpar-utils/src/bin/dpar-print-transitions.rs
+++ b/dpar-utils/src/bin/dpar-print-transitions.rs
@@ -1,7 +1,6 @@
 extern crate colored;
 extern crate conllx;
 extern crate dpar;
-#[macro_use]
 extern crate dpar_utils;
 extern crate failure;
 extern crate getopts;
@@ -68,7 +67,7 @@ where
         "stackproj" => parse_with_system::<R, W, StackProjectiveSystem>(reader, writer),
         "stackswap" => parse_with_system::<R, W, StackSwapSystem>(reader, writer),
         _ => {
-            stderr!("Unsupported transition system: {}", system);
+            eprintln!("Unsupported transition system: {}", system);
             process::exit(1);
         }
     }

--- a/dpar-utils/src/bin/dpar-train.rs
+++ b/dpar-utils/src/bin/dpar-train.rs
@@ -1,6 +1,5 @@
 extern crate conllx;
 extern crate dpar;
-#[macro_use]
 extern crate dpar_utils;
 extern crate failure;
 extern crate getopts;
@@ -10,7 +9,7 @@ extern crate tensorflow;
 
 use std::env::args;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process;
 
@@ -90,7 +89,7 @@ fn train(
         "stackproj" => Box::new(train_with_system::<StackProjectiveSystem>),
         "stackswap" => Box::new(train_with_system::<StackSwapSystem>),
         _ => {
-            stderr!("Unsupported transition system: {}", config.parser.system);
+            eprintln!("Unsupported transition system: {}", config.parser.system);
             process::exit(1);
         }
     };
@@ -226,7 +225,7 @@ where
         "stackproj" => Box::new(collect_with_system::<R, StackProjectiveSystem>),
         "stackswap" => Box::new(collect_with_system::<R, StackSwapSystem>),
         _ => {
-            stderr!("Unsupported transition system: {}", config.parser.system);
+            eprintln!("Unsupported transition system: {}", config.parser.system);
             process::exit(1);
         }
     };

--- a/dpar-utils/src/lib.rs
+++ b/dpar-utils/src/lib.rs
@@ -38,9 +38,6 @@ pub use serialization::{CborRead, CborWrite, SerializableTransitionSystem, TomlR
 mod stored_table;
 pub use stored_table::StoredLookupTable;
 
-#[macro_use]
-mod util;
-
 mod or_exit;
 pub use or_exit::OrExit;
 

--- a/dpar-utils/src/or_exit.rs
+++ b/dpar-utils/src/or_exit.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::io::Write;
 use std::process;
 
 pub trait OrExit<T> {
@@ -12,7 +11,7 @@ where
 {
     fn or_exit(self) -> T {
         self.unwrap_or_else(|e: E| -> T {
-            stderr!("Error: {}", e);
+            eprintln!("Error: {}", e);
             process::exit(1);
         })
     }

--- a/dpar-utils/src/util.rs
+++ b/dpar-utils/src/util.rs
@@ -1,7 +1,0 @@
-#[macro_export]
-macro_rules! stderr(
-    ($($arg:tt)*) => { {
-        let r = writeln!(&mut ::std::io::stderr(), $($arg)*);
-        r.expect("failed printing to stderr");
-    } }
-);

--- a/dpar/src/macros.rs
+++ b/dpar/src/macros.rs
@@ -27,11 +27,3 @@ macro_rules! try_ok {
         }
     };
 }
-
-#[macro_export]
-macro_rules! stderr(
-    ($($arg:tt)*) => { {
-        let r = writeln!(&mut ::std::io::stderr(), $($arg)*);
-        r.expect("failed printing to stderr");
-    } }
-);


### PR DESCRIPTION
dpar still used a custom macro for printing to stderr. Use eprintln,
which was introduced in Rust 1.19 instead.