### PR TITLE
Clean up some macros.

### DIFF
--- a/dpar/src/features/addr.rs
+++ b/dpar/src/features/addr.rs
@@ -128,7 +128,7 @@ impl AddressedValue {
                 .head(token)
                 .map(|dep| Cow::Borrowed(dep.relation.as_str())),
             Layer::Feature(ref feat) => {
-                let feature_map = try_ok!(state.features()[token].map(Features::as_map));
+                let feature_map = state.features()[token].map(Features::as_map)?;
 
                 // Return None when the feature or the feature value is absent.
                 feature_map

--- a/dpar/src/macros.rs
+++ b/dpar/src/macros.rs
@@ -1,29 +1,8 @@
-#[macro_export]
-macro_rules! ok_or_continue {
-    ($expr:expr) => {
+macro_rules! ok_or {
+    ($expr:expr, $none_expr:expr) => {
         match $expr {
             Some(val) => val,
-            None => continue,
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! ok_or_break {
-    ($expr:expr) => {
-        match $expr {
-            Some(val) => val,
-            None => break,
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! try_ok {
-    ($expr:expr) => {
-        match $expr {
-            Some(val) => val,
-            None => return None,
+            None => $none_expr,
         }
     };
 }

--- a/dpar/src/models/tensorflow/model.rs
+++ b/dpar/src/models/tensorflow/model.rs
@@ -100,7 +100,7 @@ where
         let mut graph_ops = EnumMap::new();
 
         for (layer, op_name) in &self.0 {
-            let op_name = ok_or_continue!(op_name.as_ref());
+            let op_name = ok_or!(op_name.as_ref(), continue);
             graph_ops[layer] = Some(op_name.to_graph_op(graph)?);
         }
 
@@ -498,7 +498,7 @@ fn add_to_args<'l>(
     input_tensors: &'l LayerTensors<i32>,
 ) {
     for (layer, layer_op) in &layer_ops.0 {
-        let layer_op = ok_or_continue!(layer_op.as_ref());
+        let layer_op = ok_or!(layer_op.as_ref(), continue);
 
         match layer_op {
             &LayerOp::Embedding {


### PR DESCRIPTION
- Remove the `try_ok` macro. This macro was introduced before the `?`
  operator was defined for `Option`. Replace its uses by `?`.
- Replace `ok_or_break` and `ok_or_continue` by the `ok_or` macro that
  takes an expression as its second argument:

  ok_or_continue!(yadda)

  becomes:

  ok_or!(yadda, continue)