### PR TITLE
Add retrieval of addressed values to transition system(s)

### DIFF
--- a/dpar/src/system/mod.rs
+++ b/dpar/src/system/mod.rs
@@ -10,7 +10,7 @@ mod parser_state;
 pub use self::parser_state::ParserState;
 
 mod trans_system;
-pub use self::trans_system::{Transition, TransitionLookup, TransitionSystem};
+pub use self::trans_system::{AttachmentAddr, Transition, TransitionLookup, TransitionSystem};
 
 pub fn sentence_to_dependencies(sentence: &Sentence) -> Result<DependencySet, Error> {
     let mut dependencies = HashSet::new();

--- a/dpar/src/system/trans_system.rs
+++ b/dpar/src/system/trans_system.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use serde::de::DeserializeOwned;
 use serde::{Serialize, Serializer};
 
+use features::addr::Source;
 use guide::Guide;
 use numberer::Numberer;
 use system::{DependencySet, ParserState};
@@ -14,9 +15,39 @@ pub trait TransitionSystem {
     type Transition: Transition;
     type Oracle: Guide<Transition = Self::Transition>;
 
+    /// Parser state addresses undergoing attachment.
+    ///
+    /// This constant stores the addresses undergoing attachment in
+    /// the transition system, typically through a left-arc or
+    /// right-arc transition.
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr);
+
     fn is_terminal(state: &ParserState) -> bool;
     fn oracle(gold_dependencies: &DependencySet) -> Self::Oracle;
     fn transitions(&self) -> &TransitionLookup<Self::Transition>;
+}
+
+/// A pair of parser state addresses undergoing attachment.
+///
+/// Instances of this struct encode parser state addresses that
+/// undergo attachment. For example, the following instance:
+///
+/// ~~~
+/// use dpar::features::addr::Source;
+/// use dpar::system::AttachmentAddr;
+///
+/// AttachmentAddr {
+///   head: Source::Stack(0),
+///   dependent: Source::Stack(1),
+/// };
+/// ~~~
+///
+/// Encodes that attachments are made between the tip and second
+/// element of the stack, where the stack tip token acts as the head.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct AttachmentAddr {
+    pub head: Source,
+    pub dependent: Source,
 }
 
 pub trait Transition: Clone + Debug + Eq + Hash + Serialize + DeserializeOwned {

--- a/dpar/src/systems/arc_eager.rs
+++ b/dpar/src/systems/arc_eager.rs
@@ -4,6 +4,9 @@ use guide::Guide;
 use system::{
     Dependency, DependencySet, ParserState, Transition, TransitionLookup, TransitionSystem,
 };
+
+use features::addr::Source;
+use system::AttachmentAddr;
 use systems::util::dep_head_mapping;
 
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
@@ -31,6 +34,17 @@ impl Default for ArcEagerSystem {
 impl TransitionSystem for ArcEagerSystem {
     type Transition = ArcEagerTransition;
     type Oracle = ArcEagerOracle;
+
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr) = (
+        AttachmentAddr {
+            head: Source::Buffer(0),
+            dependent: Source::Stack(0),
+        },
+        AttachmentAddr {
+            head: Source::Stack(0),
+            dependent: Source::Buffer(0),
+        },
+    );
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty()

--- a/dpar/src/systems/arc_hybrid.rs
+++ b/dpar/src/systems/arc_hybrid.rs
@@ -5,6 +5,8 @@ use system::{
     Dependency, DependencySet, ParserState, Transition, TransitionLookup, TransitionSystem,
 };
 
+use features::addr::Source;
+use system::AttachmentAddr;
 use systems::util::dep_head_mapping;
 
 /// The arc-hybrid transition system.
@@ -33,6 +35,17 @@ impl Default for ArcHybridSystem {
 impl TransitionSystem for ArcHybridSystem {
     type Transition = ArcHybridTransition;
     type Oracle = ArcHybridOracle;
+
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr) = (
+        AttachmentAddr {
+            head: Source::Buffer(0),
+            dependent: Source::Stack(0),
+        },
+        AttachmentAddr {
+            head: Source::Stack(1),
+            dependent: Source::Stack(0),
+        },
+    );
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1

--- a/dpar/src/systems/arc_standard.rs
+++ b/dpar/src/systems/arc_standard.rs
@@ -5,6 +5,8 @@ use system::{
     Dependency, DependencySet, ParserState, Transition, TransitionLookup, TransitionSystem,
 };
 
+use features::addr::Source;
+use system::AttachmentAddr;
 use systems::util::dep_head_mapping;
 
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
@@ -29,6 +31,17 @@ impl Default for ArcStandardSystem {
 impl TransitionSystem for ArcStandardSystem {
     type Transition = ArcStandardTransition;
     type Oracle = ArcStandardOracle;
+
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr) = (
+        AttachmentAddr {
+            head: Source::Buffer(0),
+            dependent: Source::Stack(0),
+        },
+        AttachmentAddr {
+            head: Source::Stack(0),
+            dependent: Source::Buffer(0),
+        },
+    );
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty()
@@ -68,6 +81,7 @@ impl Transition for ArcStandardTransition {
 
     fn apply(&self, state: &mut ParserState) {
         let stack_size = state.stack().len();
+
         match self {
             &ArcStandardTransition::LeftArc(ref rel) => {
                 let head = state.buffer()[0];

--- a/dpar/src/systems/stack_projective.rs
+++ b/dpar/src/systems/stack_projective.rs
@@ -5,6 +5,8 @@ use system::{
     Dependency, DependencySet, ParserState, Transition, TransitionLookup, TransitionSystem,
 };
 
+use features::addr::Source;
+use system::AttachmentAddr;
 use systems::util::dep_head_mapping;
 
 #[derive(Eq, PartialEq, Serialize, Deserialize)]
@@ -29,6 +31,17 @@ impl Default for StackProjectiveSystem {
 impl TransitionSystem for StackProjectiveSystem {
     type Transition = StackProjectiveTransition;
     type Oracle = StackProjectiveOracle;
+
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr) = (
+        AttachmentAddr {
+            head: Source::Stack(0),
+            dependent: Source::Stack(1),
+        },
+        AttachmentAddr {
+            head: Source::Stack(1),
+            dependent: Source::Stack(0),
+        },
+    );
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1
@@ -64,6 +77,7 @@ impl Transition for StackProjectiveTransition {
 
     fn apply(&self, state: &mut ParserState) {
         let stack_size = state.stack().len();
+
         match self {
             &StackProjectiveTransition::LeftArc(ref rel) => {
                 let head = state.stack()[stack_size - 1];

--- a/dpar/src/systems/stack_swap.rs
+++ b/dpar/src/systems/stack_swap.rs
@@ -8,6 +8,9 @@ use guide::Guide;
 use system::{
     Dependency, DependencySet, ParserState, Transition, TransitionLookup, TransitionSystem,
 };
+
+use features::addr::Source;
+use system::AttachmentAddr;
 use systems::util::dep_head_mapping;
 
 /// The stack-swap transition system for non-projective parsing.
@@ -40,6 +43,17 @@ impl Default for StackSwapSystem {
 impl TransitionSystem for StackSwapSystem {
     type Transition = StackSwapTransition;
     type Oracle = StackSwapOracle;
+
+    const ATTACHMENT_ADDRS: (AttachmentAddr, AttachmentAddr) = (
+        AttachmentAddr {
+            head: Source::Stack(0),
+            dependent: Source::Stack(1),
+        },
+        AttachmentAddr {
+            head: Source::Stack(1),
+            dependent: Source::Stack(0),
+        },
+    );
 
     fn is_terminal(state: &ParserState) -> bool {
         state.buffer().is_empty() && state.stack().len() == 1


### PR DESCRIPTION
This PR adds functionality to retrieve the addresses of the two tokens between which a dependency relation is established. Depending on the transition system, these are tokens from the stack or buffer.