### PR TITLE
Add updated config

### DIFF
--- a/dpar-utils/testdata/extended-parse.conf
+++ b/dpar-utils/testdata/extended-parse.conf
@@ -1,0 +1,47 @@
+[parser]
+pproj = true
+system = "stackproj"
+inputs = "parser.inputs"
+transitions = "parser.transitions"
+train_batch_size = 8192
+parse_batch_size = 8192
+
+[model]
+graph = "parser.graph"
+parameters = "params"
+intra_op_parallelism_threads = 2
+inter_op_parallelism_threads = 2
+
+[train]
+initial_lr = 0.05
+decay_rate = 0.95
+decay_steps = 10
+staircase =  true
+patience =  5
+
+[lookups]
+  [lookups.word]
+  filename = "word-vectors.bin"
+  normalize = true
+  op = "prediction/model/tokens"
+  embed_op = "prediction/model/token_embeds"
+
+  [lookups.tag]
+  filename = "tag-vectors.bin"
+  normalize = true
+  op = "prediction/model/tags"
+  embed_op = "prediction/model/tag_embeds"
+
+  [lookups.deprel]
+  filename = "deprels.lookup"
+  op = "prediction/model/deprels"
+
+  [lookups.feature]
+  filename = "features.lookup"
+  op = "prediction/model/features"
+
+  [lookups.chars]
+  filename = "char-vectors.bin"
+  normalize = true
+  op = "prediction/model/chars"
+  embed_op = "prediction/model/char_embeds"


### PR DESCRIPTION
`basic-parse.conf` doesn't seem up to date with the parser any more. A second config has been added to account for this. Alternatively, `basic-parse.conf` can also be replaced by `extended-parse.conf`.