### PR TITLE
Add updated parser config

### DIFF
--- a/dpar-utils/src/config.rs
+++ b/dpar-utils/src/config.rs
@@ -238,12 +238,14 @@ fn relativize_path(config_path: &Path, filename: &str) -> Result<String, Error> 
         .ok_or(format_err!(
             "Cannot get the parent path for the configuration file {}",
             config_path.display()
-        ))?.join(path)
+        ))?
+        .join(path)
         .to_str()
         .ok_or(format_err!(
             "Cannot convert parent path of configuration file to string: {}",
             config_path.display()
-        ))?.to_owned())
+        ))?
+        .to_owned())
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/dpar-utils/src/config_tests.rs
+++ b/dpar-utils/src/config_tests.rs
@@ -9,37 +9,14 @@ lazy_static! {
             system: String::from("stackproj"),
             inputs: String::from("parser.inputs"),
             transitions: String::from("parser.transitions"),
-            train_batch_size: 8000,
-            parse_batch_size: 4000,
+            train_batch_size: 8192,
+            parse_batch_size: 8192,
         },
         model: Model {
-            graph: String::from("model.bin"),
+            graph: String::from("parser.graph"),
             parameters: String::from("params"),
-            intra_op_parallelism_threads: 4,
-            inter_op_parallelism_threads: 6,
-        },
-        lookups: Lookups {
-            word: Some(Lookup::Embedding {
-                filename: String::from("word-vectors.bin"),
-                normalize: true,
-                op: String::from("word_op"),
-                embed_op: String::from("word_embed_op"),
-            }),
-            tag: Some(Lookup::Embedding {
-                filename: String::from("tag-vectors.bin"),
-                normalize: true,
-                op: String::from("tag_op"),
-                embed_op: String::from("tag_embed_op"),
-            }),
-            deprel: Some(Lookup::Embedding {
-                filename: String::from("deprel-vectors.bin.real"),
-                normalize: false,
-                op: String::from("deprel_op"),
-                embed_op: String::from("deprel_embed_op"),
-            }),
-
-            chars: None,
-            feature: None
+            intra_op_parallelism_threads: 2,
+            inter_op_parallelism_threads: 2,
         },
         train: Train {
             initial_lr: 0.05.into(),
@@ -47,6 +24,34 @@ lazy_static! {
             decay_steps: 10,
             staircase: true,
             patience: 5,
+        },
+        lookups: Lookups {
+            word: Some(Lookup::Embedding {
+                filename: String::from("word-vectors.bin"),
+                normalize: true,
+                op: String::from("model/tokens"),
+                embed_op: String::from("model/token_embeds"),
+            }),
+            tag: Some(Lookup::Embedding {
+                filename: String::from("tag-vectors.bin"),
+                normalize: true,
+                op: String::from("model/tags"),
+                embed_op: String::from("model/tag_embeds"),
+            }),
+            deprel: Some(Lookup::Table {
+                filename: String::from("deprels.lookup"),
+                op: String::from("model/deprels"),
+            }),
+            feature: Some(Lookup::Table {
+                filename: String::from("features.lookup"),
+                op: String::from("model/features"),
+            }),
+            chars: Some(Lookup::Embedding {
+                filename: String::from("char-vectors.bin"),
+                normalize: true,
+                op: String::from("model/chars"),
+                embed_op: String::from("model/char_embeds"),
+            })
         }
     };
 }

--- a/dpar-utils/testdata/basic-parse.conf
+++ b/dpar-utils/testdata/basic-parse.conf
@@ -3,14 +3,14 @@ pproj = true
 system = "stackproj"
 inputs = "parser.inputs"
 transitions = "parser.transitions"
-train_batch_size = 8000
-parse_batch_size = 4000
+train_batch_size = 8192
+parse_batch_size = 8192
 
 [model]
-graph = "model.bin"
+graph = "parser.graph"
 parameters = "params"
-intra_op_parallelism_threads = 4
-inter_op_parallelism_threads = 6
+intra_op_parallelism_threads = 2
+inter_op_parallelism_threads = 2
 
 [train]
 initial_lr = 0.05
@@ -23,17 +23,25 @@ patience =  5
   [lookups.word]
   filename = "word-vectors.bin"
   normalize = true
-  op = "word_op"
-  embed_op = "word_embed_op"
+  op = "model/tokens"
+  embed_op = "model/token_embeds"
 
   [lookups.tag]
   filename = "tag-vectors.bin"
   normalize = true
-  op = "tag_op"
-  embed_op = "tag_embed_op"
+  op = "model/tags"
+  embed_op = "model/tag_embeds"
 
   [lookups.deprel]
-  filename = "deprel-vectors.bin.real"
-  normalize = false
-  op = "deprel_op"
-  embed_op = "deprel_embed_op"
+  filename = "deprels.lookup"
+  op = "model/deprels"
+
+  [lookups.feature]
+  filename = "features.lookup"
+  op = "model/features"
+
+  [lookups.chars]
+  filename = "char-vectors.bin"
+  normalize = true
+  op = "model/chars"
+  embed_op = "model/char_embeds"


### PR DESCRIPTION
`basic-parse.conf` doesn't seem to be up to date with the parser anymore. A second config has been added to account for this. Alternatively, `basic-parse.conf` could also be replaced by `extended-parse.conf`.