### PR TITLE
Extend feature_name rule to allow for dashes and underscores.

### DIFF
--- a/dpar/src/features/addr.pest
+++ b/dpar/src/features/addr.pest
@@ -22,7 +22,7 @@ tag_layer = { "TAG" }
 token_layer = { "TOKEN" }
 
 // Layer arguments.
-feature_name = ${ ASCII_ALPHANUMERIC+ }
+feature_name = ${ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_" | "-" )+ }
 affix_len = ${ ASCII_DIGIT+ }
 
 addr = { "[" ~ initial_source ~ ("," ~ dep_source)* ~ "]" }

--- a/dpar/src/features/parse_addr_tests.rs
+++ b/dpar/src/features/parse_addr_tests.rs
@@ -11,8 +11,7 @@ static CORRECT_STRING2: &'static str = "[BUFFER 1] TAG";
 static CORRECT_STRING3: &'static str = "[STACK 0, LDEP 0] DEPREL";
 static CORRECT_STRING4: &'static str = "[STACK 0, LDEP 0] DEPREL [STACK 0, RDEP 0] DEPREL";
 static CORRECT_STRING5: &'static str = "[STACK 0] FEATURE num";
-static CORRECT_STRING6: &'static str =
-    "[STACK 0,\n  LDEP 0]\n  DEPREL\n  [STACK 0,\n RDEP 0] DEPREL";
+static CORRECT_STRING6: &'static str = "[STACK 0] FEATURE under_score";
 
 lazy_static! {
     static ref CORRECT1: Vec<AddressedValue> = vec![AddressedValue {
@@ -41,13 +40,17 @@ lazy_static! {
         address: vec![Source::Stack(0)],
         layer: Layer::Feature("num".to_owned()),
     }];
+    static ref CORRECT6: Vec<AddressedValue> = vec![AddressedValue {
+        address: vec![Source::Stack(0)],
+        layer: Layer::Feature("under_score".to_owned()),
+    }];
     static ref CORRECT_CASES: HashMap<&'static str, Vec<AddressedValue>> = hashmap! {
         CORRECT_STRING1 => CORRECT1.clone(),
         CORRECT_STRING2 => CORRECT2.clone(),
         CORRECT_STRING3 => CORRECT3.clone(),
         CORRECT_STRING4 => CORRECT4.clone(),
         CORRECT_STRING5 => CORRECT5.clone(),
-        CORRECT_STRING6 => CORRECT4.clone(),
+        CORRECT_STRING6 => CORRECT6.clone(),
     };
     static ref INCORRECT_CASES: Vec<&'static str> = vec![
         "[] TOKEN",
@@ -72,6 +75,8 @@ lazy_static! {
         "[STACK 0, LDEP 0, BUFFER 0] TOKEN",
         "[STACK\n0, LDEP 0] DEPREL",
         "[STACK 0, LDEP 0] FEATURE\ntf",
+        "[STACK 0] FEATURE _",
+        "[STACK 0] FEATURE _leading",
     ];
 }
 


### PR DESCRIPTION
Should solve #37 

This PR extends the feature_name rule in the pest grammar to accept underscores and dashes.

If we want to allow word-initial underscores and dashes or features named "-" and "_", we can change the rule accordingly:
```
feature_name = ${ (ASCII_ALPHANUMERIC | "_" | "-" )+ } 
```