### PR TITLE
Make TensorflowModel the owner of the system and vectorizer

### DIFF
--- a/dpar-utils/src/bin/dpar-parse.rs
+++ b/dpar-utils/src/bin/dpar-parse.rs
@@ -102,7 +102,7 @@ where
     let layer_ops = config.lookups.layer_ops();
     let vectorizer = InputVectorizer::new(lookups, inputs);
     let system: S = load_system_generic(config)?;
-    let guide = load_model(&config, system, &vectorizer, &layer_ops)?;
+    let guide = load_model(&config, system, vectorizer, &layer_ops)?;
     let parser = GreedyParser::new(guide);
 
     let mut n_sents = 0;
@@ -222,12 +222,12 @@ where
     }
 }
 
-fn load_model<'a, T>(
+fn load_model<T>(
     config: &Config,
     system: T,
-    vectorizer: &'a InputVectorizer,
+    vectorizer: InputVectorizer,
     layer_ops: &LayerOps<String>,
-) -> Result<TensorflowModel<'a, T>, Error>
+) -> Result<TensorflowModel<T>, Error>
 where
     T: TransitionSystem,
 {

--- a/dpar/src/models/tensorflow/guide.rs
+++ b/dpar/src/models/tensorflow/guide.rs
@@ -4,7 +4,7 @@ use crate::guide::{BatchGuide, Guide};
 use crate::models::tensorflow::{InstanceSlices, LayerTensors, TensorflowModel};
 use crate::system::{ParserState, TransitionSystem};
 
-impl<'a, T> Guide for TensorflowModel<'a, T>
+impl<T> Guide for TensorflowModel<T>
 where
     T: TransitionSystem,
 {
@@ -15,7 +15,7 @@ where
     }
 }
 
-impl<'a, T> BatchGuide for TensorflowModel<'a, T>
+impl<T> BatchGuide for TensorflowModel<T>
 where
     T: TransitionSystem,
 {

--- a/dpar/src/models/tensorflow/model.rs
+++ b/dpar/src/models/tensorflow/model.rs
@@ -113,13 +113,13 @@ impl<S> LayerOps<S> {
 /// and `validate` methods. Moreover, a trained graph can be used to
 /// predict the best transition given a parser state using
 /// `predict_best_transition`.
-pub struct TensorflowModel<'a, T>
+pub struct TensorflowModel<T>
 where
     T: TransitionSystem,
 {
     session: Session,
     system: T,
-    vectorizer: &'a InputVectorizer,
+    vectorizer: InputVectorizer,
     layer_ops: LayerOps<Operation>,
     init_op: Operation,
     restore_op: Operation,
@@ -135,7 +135,7 @@ where
     train_op: Operation,
 }
 
-impl<'a, T> TensorflowModel<'a, T>
+impl<T> TensorflowModel<T>
 where
     T: TransitionSystem,
 {
@@ -147,7 +147,7 @@ where
         config_protobuf: &[u8],
         model_protobuf: &[u8],
         system: T,
-        vectorizer: &'a InputVectorizer,
+        vectorizer: InputVectorizer,
         op_names: &LayerOps<S>,
     ) -> Result<Self, Error>
     where
@@ -181,7 +181,7 @@ where
         model_protobuf: &[u8],
         parameters_path: P,
         system: T,
-        vectorizer: &'a InputVectorizer,
+        vectorizer: InputVectorizer,
         op_names: &LayerOps<S>,
     ) -> Result<Self, Error>
     where
@@ -220,7 +220,7 @@ where
         config_protobuf: &[u8],
         model_protobuf: &[u8],
         system: T,
-        vectorizer: &'a InputVectorizer,
+        vectorizer: InputVectorizer,
         op_names: &LayerOps<S>,
     ) -> Result<Self, Error>
     where
@@ -382,6 +382,11 @@ where
         self.session.run(&mut args).map_err(status_to_error)
     }
 
+    /// Get the transition system used by the model.
+    pub fn system(&self) -> &T {
+        &self.system
+    }
+
     /// Perform a training step.
     ///
     /// This method updates the model parameters using a batch of parser
@@ -541,7 +546,7 @@ mod tests {
         op_names.insert(Layer::DepRel, LayerOp("model/deprels"));
         op_names.insert(Layer::Feature, LayerOp("model/features"));
 
-        TensorflowModel::load_graph(&[], &data, system, &vectorizer, &op_names)
+        TensorflowModel::load_graph(&[], &data, system, vectorizer, &op_names)
             .expect("Cannot load graph.");
     }
 }


### PR DESCRIPTION
Before, TensorflowModel and TrainCollector had references to the
system and vectorizer. This change TensorflowModel makes
TensorFlowmodel the owner of both, reducing the number of lifetime
parameters. The collector borrows these from the model when needed.