### PR TITLE
Add and switch to plateau learning rate schedule

### DIFF
--- a/dpar-utils/src/bin/dpar-train.rs
+++ b/dpar-utils/src/bin/dpar-train.rs
@@ -126,11 +126,12 @@ where
 
     let mut best_epoch = 0;
     let mut best_acc = 0.0;
+    let mut last_acc = 0.0;
 
-    let lr_schedule = config.train.lr_schedule();
+    let mut lr_schedule = config.train.lr_schedule();
 
     for epoch in 0.. {
-        let lr = lr_schedule.learning_rate(epoch);
+        let lr = lr_schedule.learning_rate(epoch, last_acc);
 
         let (loss, acc) = run_epoch(config, &mut model, &train_data, true, lr)?;
         eprintln!(
@@ -143,6 +144,7 @@ where
 
         let (loss, acc) = run_epoch(config, &mut model, &validation_data, false, lr)?;
 
+        last_acc = acc;
         if acc > best_acc {
             best_epoch = epoch;
             best_acc = acc;

--- a/dpar-utils/src/config.rs
+++ b/dpar-utils/src/config.rs
@@ -14,7 +14,7 @@ use tf_proto::ConfigProto;
 
 use dpar::features;
 use dpar::features::{AddressedValues, Embeddings, Layer, LayerLookups};
-use dpar::models::lr::ExponentialDecay;
+use dpar::models::lr::PlateauLearningRate;
 use dpar::models::tensorflow::{LayerOp, LayerOps};
 
 use crate::StoredLookupTable;
@@ -263,19 +263,17 @@ impl Model {
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Train {
     pub initial_lr: NotNan<f32>,
-    pub decay_rate: NotNan<f32>,
-    pub decay_steps: usize,
-    pub staircase: bool,
+    pub lr_scale: NotNan<f32>,
+    pub lr_patience: usize,
     pub patience: usize,
 }
 
 impl Train {
-    pub fn lr_schedule(&self) -> ExponentialDecay {
-        ExponentialDecay::new(
+    pub fn lr_schedule(&self) -> PlateauLearningRate {
+        PlateauLearningRate::new(
             self.initial_lr.into_inner(),
-            self.decay_rate.into_inner(),
-            self.decay_steps,
-            self.staircase,
+            self.lr_scale.into_inner(),
+            self.lr_patience,
         )
     }
 }

--- a/dpar-utils/src/config_tests.rs
+++ b/dpar-utils/src/config_tests.rs
@@ -22,10 +22,9 @@ lazy_static! {
         },
         train: Train {
             initial_lr: 0.05.into(),
-            decay_rate: 0.95.into(),
-            decay_steps: 10,
-            staircase: true,
-            patience: 5,
+            lr_scale: 0.5.into(),
+            lr_patience: 5,
+            patience: 10,
         },
         lookups: Lookups {
             word: Some(Lookup::Embedding {

--- a/dpar-utils/testdata/basic-parse.conf
+++ b/dpar-utils/testdata/basic-parse.conf
@@ -14,10 +14,9 @@ inter_op_parallelism_threads = 2
 
 [train]
 initial_lr = 0.05
-decay_rate = 0.95
-decay_steps = 10
-staircase =  true
-patience =  5
+lr_scale = 0.5
+lr_patience = 5
+patience = 10
 
 [lookups]
   [lookups.word]


### PR DESCRIPTION
This schedule scales the learning rate if a plateau has been reached for
a certain number of epochs.